### PR TITLE
Support FORCE-OUTPUT on PACKET-IO-STREAM

### DIFF
--- a/src/packet-io-stream.lisp
+++ b/src/packet-io-stream.lisp
@@ -81,6 +81,11 @@
   (with-slots (stream) pio-stream
     (trivial-gray-streams:stream-finish-output stream)))
 
+(defmethod trivial-gray-streams:stream-force-output
+    ((pio-stream packet-io-stream))
+  (with-slots (stream) pio-stream
+    (trivial-gray-streams:stream-force-output stream)))
+
 (defmethod trivial-gray-streams:stream-line-column
   ((pio-stream packet-io-stream))
   (with-slots (stream) pio-stream


### PR DESCRIPTION
Currently, calling FORCE-OUTPUT from any command cause an error because PACKET-IO-STREAM does not support this operation. This patch adds that support.